### PR TITLE
feat: add client, server, and shared starters

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+
+const App = () => <h1>Hello World</h1>;
+
+ReactDOM.createRoot(document.getElementById("root")!).render(<App />);

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,12 @@
+import express from "express";
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.get("/", (_req, res) => {
+  res.send("Server running");
+});
+
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const exampleSchema = z.object({
+  message: z.string(),
+});
+
+export type Example = z.infer<typeof exampleSchema>;


### PR DESCRIPTION
## Summary
- scaffold client folder with index and React entry
- add minimal Express server entry point
- share an example schema via zod

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b9def34ff083239cb883e862143400