### PR TITLE
Add test infrastructure and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -101,7 +102,9 @@
     "tailwindcss": "^3.4.17",
     "tsx": "^4.19.1",
     "typescript": "5.6.3",
-    "vite": "^5.4.19"
+    "vite": "^5.4.19",
+    "vitest": "^1.6.0",
+    "supertest": "^7.0.0"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,12 +1,14 @@
 import express from "express";
 
-const app = express();
+export const app = express();
 const port = process.env.PORT || 3000;
 
 app.get("/", (_req, res) => {
   res.send("Server running");
 });
 
-app.listen(port, () => {
-  console.log(`Server listening on port ${port}`);
-});
+if (process.env.NODE_ENV !== "test") {
+  app.listen(port, () => {
+    console.log(`Server listening on port ${port}`);
+  });
+}

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1,0 +1,11 @@
+import request from 'supertest';
+import { describe, it, expect } from 'vitest';
+import { app } from '../server/index';
+
+describe('GET /', () => {
+  it('responds with Server running', async () => {
+    const res = await request(app).get('/');
+    expect(res.status).toBe(200);
+    expect(res.text).toBe('Server running');
+  });
+});


### PR DESCRIPTION
## Summary
- export Express app to facilitate testing
- add Vitest and Supertest test setup with example test
- configure CI workflow to run tests on pull requests

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e4086ab08323a4c1593d435661bb