### PR TITLE
docs: add environment example and setup instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Copy this file to .env and update the values as needed
+
+# PostgreSQL connection string
+DATABASE_URL=postgres://user:password@localhost:5432/mydatabase
+
+# Port for the Express server
+PORT=3000

--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@ For more details, see [replit.md](./replit.md).
 ## Installation
 
 1. Clone this repo.
-2. Install dependencies:
+2. Copy `.env.example` to `.env` and fill in the required values such as `DATABASE_URL`:
+   ```bash
+   cp .env.example .env
+   ```
+3. Install dependencies:
    ```bash
    npm install
    ```


### PR DESCRIPTION
## Summary
- add `.env.example` showing required environment variables
- document copying `.env.example` for local setup

## Testing
- `npm test` *(fails: command not found)*
- `npm run check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e541448883239f7f22ee2bd4842a